### PR TITLE
パスワードの最低文字数を設定

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -164,7 +164,7 @@ Devise.setup do |config|
 
   # ==> Configuration for :validatable
   # Range for password length.
-  config.password_length = 1..128
+  config.password_length = 8..128
 
   # Email regex used to validate email formats. It simply asserts that
   # one (and only one) @ exists in the given string. This is mainly


### PR DESCRIPTION
パスワードの最低文字数を8文字に設定